### PR TITLE
Updated adfly bypass

### DIFF
--- a/Link-Pass.ipynb
+++ b/Link-Pass.ipynb
@@ -52,7 +52,7 @@
         "\n",
         "url = \"\" #@param {type:\"string\"}\n",
         "print(\"You Have Entered:\")\n",
-        "print(URL)\n",
+        "print(url)\n",
         "print(\"Checking Link...\")\n",
         "'''\n",
         "404: Complete exception handling not found :(\n",


### PR DESCRIPTION
print(url) typo error